### PR TITLE
Updates to the gn2-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN /etc/init.d/mysql start && \
     gzip -dc | mysql --user=GN --password=mypass db_webqtl
 
 # fetch the list of Python module dependencies
-RUN wget --quiet https://raw.githubusercontent.com/zsloan/genenetwork2/master/misc/requirements.txt
+RUN wget --quiet https://raw.githubusercontent.com/dannyarends/genenetwork2/master/misc/requirements.txt
 
 # install pp module separately
 RUN wget http://www.parallelpython.com/downloads/pp/pp-1.6.3.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,6 @@ COPY run_gn2_server.sh /root/
 COPY supervisord.conf /etc/supervisor/conf.d/
 RUN mkdir -p /var/log/supervisor
 
-EXPOSE 80
-
 # until path settings are introduced, simply use the same path
 RUN mkdir -p /home/zas1024
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,4 +86,6 @@ RUN mkdir -p /home/zas1024
 RUN wget http://pngu.mgh.harvard.edu/~purcell/plink/dist/plink-1.07-x86_64.zip && \
     unzip plink-1.07-x86_64.zip -d /home/zas1024
 
+RUN git clone git@github.com:genenetwork/pylmm_gn2.git /home/zas1024/pyLMM
+
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,8 @@ EXPOSE 80
 # until path settings are introduced, simply use the same path
 RUN mkdir -p /home/zas1024
 
+# download and install / unpack plink (a requirement)
+RUN wget http://pngu.mgh.harvard.edu/~purcell/plink/dist/plink-1.07-x86_64.zip && \
+    unzip plink-1.07-x86_64.zip -d /home/zas1024
+
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/a
 
 # install the software
 RUN apt-get update && \
-    apt-get install -y python-dev libmysqlclient-dev \
+    apt-get install -y python-dev libffi-dev libmysqlclient-dev \
     libatlas-base-dev gfortran g++ python-pip libyaml-dev \
     mysql-server r-base r-base-dev colordiff ntp ufw wget \
     redis-server nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,20 @@ WORKDIR /root
 
 # based on https://github.com/zsloan/genenetwork2/blob/master/misc/gn_installation_notes.txt
 
+# Add keys an source to install the latest stable version of R
+RUN echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" > /etc/apt/sources.list.d/r-stable-trusty.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+
+# Add keys an source to install the latest stable version of nginx
+RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx-stable-trusty.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C && \
+
 # install the software
 RUN apt-get update && \
     apt-get install -y python-dev libmysqlclient-dev \
     libatlas-base-dev gfortran g++ python-pip libyaml-dev \
-    mysql-server r-base-dev colordiff ntp ufw wget \
-    redis-server
-
-RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx-stable-trusty.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C && \
-    apt-get update && \
-    apt-get install -y nginx
+    mysql-server r-base r-base-dev colordiff ntp ufw wget \
+    redis-server nginx
 
 # install virtualenv, set default interpreter to bash
 RUN pip install virtualenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" > /etc/apt/sourc
 
 # Add keys an source to install the latest stable version of nginx
 RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx-stable-trusty.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C
 
 # install the software
 RUN apt-get update && \
-    apt-get install -y python-dev libffi-dev libmysqlclient-dev \
+    apt-get install -y apt-utils git python-dev libffi-dev libmysqlclient-dev \
     libatlas-base-dev gfortran g++ python-pip libyaml-dev \
     mysql-server r-base r-base-dev colordiff ntp ufw wget \
     redis-server nginx
@@ -86,6 +86,8 @@ RUN mkdir -p /home/zas1024
 RUN wget http://pngu.mgh.harvard.edu/~purcell/plink/dist/plink-1.07-x86_64.zip && \
     unzip plink-1.07-x86_64.zip -d /home/zas1024
 
+# download and install pyLMM inside the docker image (for development you might want to add it from the localhost on the docker run commandline)
+# docker run -i -t -v $(pwd):/home/zas1024/gene -v /path/to/pylmm_gn2/:/home/zas1024/pyLMM -p 5003:5003 gn
 RUN git clone git@github.com:genenetwork/pylmm_gn2.git /home/zas1024/pyLMM
 
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,6 @@ RUN wget http://pngu.mgh.harvard.edu/~purcell/plink/dist/plink-1.07-x86_64.zip &
 
 # download and install pyLMM inside the docker image (for development you might want to add it from the localhost on the docker run commandline)
 # docker run -i -t -v $(pwd):/home/zas1024/gene -v /path/to/pylmm_gn2/:/home/zas1024/pyLMM -p 5003:5003 gn
-RUN git clone git@github.com:genenetwork/pylmm_gn2.git /home/zas1024/pyLMM
+RUN git clone https://github.com/genenetwork/pylmm_gn2.git /home/zas1024/pyLMM
 
 CMD ["/usr/bin/supervisord"]

--- a/my_settings.py
+++ b/my_settings.py
@@ -1,4 +1,5 @@
 DB_URI="mysql://GN:mypass@localhost/db_webqtl"
 SECRET_HMAC_CODE="secretkey"
-PYLMM_PATH="/home/zas1024/gene/wqflask/wqflask/my_pylmm/pyLMM"
+PYLMM_PATH="/home/zas1024/pyLMM"
+PLINK_PATH="/home/zas1024/plink-1.07-x86_64"
 SERVER_PORT=5003

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,4 +9,8 @@ command=redis-server
 
 [program:gn2]
 command=/bin/bash /root/run_gn2_server.sh
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
 autorestart=unexpected


### PR DESCRIPTION
I updated the gn2-docker repository so that it runs on my machine (ubuntu 14.04)

Some bugfixes / things I needed to fix to get it working:
- The R-version required for Rpy has been updated to > 3.0.2 (which is the default in the repos), so we now instal the latest version from http://cran.rstudio.com/bin/linux/ubuntu
- Added the installation of libffi, which is required by cairosvg
- The requirements.txt file is malformed in zach's repository so I download it from mine (should be genenetwork/genenetwork2)
- Install plink into the docker image, since it is required (I used the 64 bit version, I dont know if we should use 64 or 32 bit)
- pylmm need to be available to run GN2 there are 2 ways fo doing this, both have their merits:
  - 1. Clone the repository inside the docker container using the docker file (I implemented this)
  - 2. Export the repository via the 'docker run' command line  by adding an additional path parameter: -v /path/to/pylmm:/home/zas1024/pyLMM
- Removed the EXPOSE 80 call, which did not do anything

Enhancements:
- It now redirect stdout and stderr using supervisord within the docker container to show what the server is doing (and provide error / debug reports)

Still remaining:
- When booting up the dockerimage, gn2 doesn't not always start the first time, while mysql is not running yet. However it autorestarts using the supervisord, and always runs the second time
